### PR TITLE
Add WSAStartup in P2P networking modules

### DIFF
--- a/source-code/src/P2PClient.cpp
+++ b/source-code/src/P2PClient.cpp
@@ -11,6 +11,16 @@
  */
 P2PClient::P2PClient()
 {
+    // Initialize WinSock for client operations
+    WSAData wsa;
+    if (WSAStartup(MAKEWORD(2, 2), &wsa) != 0) {
+        std::cerr << "[P2PClient] WSAStartup failed\n";
+    }
+}
+
+P2PClient::~P2PClient()
+{
+    WSACleanup();
 }
 bool P2PClient::sendMessageToPeer(const std::string &ip, int port, const std::string &msg, std::string &response)
 {

--- a/source-code/src/P2PServer.cpp
+++ b/source-code/src/P2PServer.cpp
@@ -15,6 +15,13 @@ P2PServer::~P2PServer() {
 void P2PServer::start() {
     if (running) return;
 
+    // Initialize WinSock
+    WSAData wsa;
+    if (WSAStartup(MAKEWORD(2, 2), &wsa) != 0) {
+        std::cerr << "[P2PServer] WSAStartup failed\n";
+        return;
+    }
+
     listenSocket = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
     if (listenSocket == INVALID_SOCKET) {
         std::cerr << "[P2PServer] socket creation failed\n";
@@ -58,6 +65,9 @@ void P2PServer::stop() {
     if (serverThread.joinable()) {
         serverThread.join();
     }
+
+    // Clean up WinSock
+    WSACleanup();
 
     std::cout << "[P2PServer] Stopped.\n";
 }


### PR DESCRIPTION
## Summary
- initialize WinSock in `P2PServer::start` and clean it up when stopping
- initialize WinSock in `P2PClient` constructor and clean it up in the destructor

## Testing
- `cmake ..` *(fails: DOWNLOAD_EXTRACT_TIMESTAMP policy warning, build stops)*
- `make` *(fails: `No targets specified and no makefile found`)*