### PR TITLE
Fix P2P sendTo call and id handling

### DIFF
--- a/source-code/src/DVM.cpp
+++ b/source-code/src/DVM.cpp
@@ -59,8 +59,14 @@ void DVM::handleBuyFlow() {
         }
     // 재고가 부족한 경우
     } else {
-        string tempMsg = msgManager.createRequestItemStockAndLocation(to_string(itemManager.getSelectedItemId()), itemManager.getSelectedItemNum());
-        msgManager.sendTo(0,tempMsg);
+        string tempMsg = msgManager.createRequestItemStockAndLocation(
+            to_string(itemManager.getSelectedItemId()),
+            itemManager.getSelectedItemNum());
+
+        for (const auto& dvm : altDVMManager.getAltDVMList()) {
+            msgManager.sendTo(dvm.getId(), tempMsg);
+        }
+
         altDVMManager.selectAltDVM(coorX, coorY);
 
         // 선결제 원하는 경우

--- a/source-code/src/MsgManager.cpp
+++ b/source-code/src/MsgManager.cpp
@@ -1,6 +1,7 @@
 #include "MsgManager.hpp"
 #include <json.hpp>
 #include <iostream>
+#include <cctype>
 
 using json = nlohmann::json;
 
@@ -58,7 +59,18 @@ std::string MsgManager::createResponsePrepayment(const std::string& dstId, const
 // 메시지 전송
 void MsgManager::sendTo(const std::string& dstId, const std::string& msg) {
     int basePort = 5000;
-    int dvmNum = std::stoi(dstId.substr(1)); // DVM id에서 숫자 추출("T2" → 2)
+    int dvmNum = 0;
+    try {
+        if (!dstId.empty() && !std::isdigit(dstId.front())) {
+            dvmNum = std::stoi(dstId.substr(1));
+        } else {
+            dvmNum = std::stoi(dstId);
+        }
+    } catch (const std::exception& e) {
+        std::cerr << "[MsgManager] Invalid dstId: " << dstId << "\n";
+        return;
+    }
+
     int targetPort = basePort + dvmNum;
     std::string response;
     p2pClient->sendMessageToPeer("127.0.0.1", targetPort, msg, response);


### PR DESCRIPTION
## Summary
- broadcast stock request to all alt DVMs instead of passing `0`
- handle numeric DVM ids correctly in `MsgManager::sendTo`

## Testing
- `cmake ..` *(fails: couldn't download googletest)*